### PR TITLE
Fix storing forbidden URLs.

### DIFF
--- a/lua/streamradio_core/cache.lua
+++ b/lua/streamradio_core/cache.lua
@@ -385,7 +385,7 @@ local function InternalDownload(url, saveas_url)
 		end
 
 		if not LIB.CanDownload( len ) then
-			forbidden[queueurl] = true
+			LIB.forbidden[queueurl] = true
 			CallCallbacks(queueurl, len, headers, -1, false)
 		end
 


### PR DESCRIPTION
Fixes this Lua error because the variable didn't have the LIB scope to it.
```
[ERROR] lua/streamradio_core/cache.lua:388: attempt to index global 'forbidden' (a nil value)
  1. onsuccess - lua/streamradio_core/cache.lua:388
   2. unknown - lua/includes/modules/http.lua:29
```