### PR TITLE
Optimize VR logic a bit

### DIFF
--- a/lua/streamradio_core/vr.lua
+++ b/lua/streamradio_core/vr.lua
@@ -6,7 +6,7 @@ local LIB = StreamRadioLib.VR
 table.Empty(LIB)
 
 function LIB.IsInstalled()
-	return istable(vrmod)
+	return vrmod ~= nil
 end
 
 function LIB.IsActive(ply)


### PR DESCRIPTION
This function is called often enough that it's better to just do `vrmod ~= nil`